### PR TITLE
Nested group

### DIFF
--- a/cmd/controller-gen/main.go
+++ b/cmd/controller-gen/main.go
@@ -107,6 +107,7 @@ Usage:
 	f := cmd.Flags()
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as cluster scoped if not set")
 	f.BoolVar(&g.SkipMapValidation, "skip-map-validation", true, "if set to true, skip generating OpenAPI validation schema for map type in CRD.")

--- a/cmd/crd/cmd/generate.go
+++ b/cmd/crd/cmd/generate.go
@@ -62,6 +62,7 @@ func GeneratorForFlags(f *flag.FlagSet) *crdgenerator.Generator {
 	g := &crdgenerator.Generator{}
 	f.StringVar(&g.RootPath, "root-path", "", "working dir, must have PROJECT file under the path or parent path if domain not set")
 	f.StringVar(&g.OutputDir, "output-dir", "", "output directory, default to 'config/crds' under root path")
+	f.BoolVar(&g.NestedOutput, "nested", false, "nested output layout: group/version/kind.yaml")
 	f.StringVar(&g.Domain, "domain", "", "domain of the resources, will try to fetch it from PROJECT file if not specified")
 	// TODO: Do we need this? Is there a possibility that a crd is namespace scoped?
 	f.StringVar(&g.Namespace, "namespace", "", "CRD namespace, treat it as root scoped if not set")

--- a/pkg/crd/generator/generator.go
+++ b/pkg/crd/generator/generator.go
@@ -38,6 +38,7 @@ import (
 type Generator struct {
 	RootPath          string
 	OutputDir         string
+	NestedOutput      bool
 	Domain            string
 	Namespace         string
 	SkipMapValidation bool
@@ -135,6 +136,10 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 
 	for file, crd := range crds {
 		outFile := path.Join(c.OutputDir, file)
+		// If nested output selected: construct nested path 'group/version/kind'
+		if c.NestedOutput {
+			outFile = path.Join(append([]string{c.OutputDir}, strings.Split(file, "_")...)...)
+		}
 		if err := (&util.FileWriter{Fs: c.OutFs}).WriteFile(outFile, crd); err != nil {
 			return err
 		}
@@ -142,8 +147,20 @@ func (c *Generator) writeCRDs(crds map[string][]byte) error {
 	return nil
 }
 
+func getGroupElements(group string) []string {
+	ss := strings.Split(group, ".")
+	if len(ss) > 1 {
+		// reverse slice
+		for i := len(ss)/2 - 1; i >= 0; i-- {
+			opp := len(ss) - 1 - i
+			ss[i], ss[opp] = ss[opp], ss[i]
+		}
+	}
+	return ss
+}
+
 func getCRDFileName(resource *codegen.APIResource) string {
-	elems := []string{resource.Group, resource.Version, strings.ToLower(resource.Kind)}
+	elems := append(getGroupElements(resource.Group), resource.Version, strings.ToLower(resource.Kind))
 	return strings.Join(elems, "_") + ".yaml"
 }
 

--- a/pkg/internal/codegen/parse/util.go
+++ b/pkg/internal/codegen/parse/util.go
@@ -233,13 +233,12 @@ func hasSingular(t *types.Type) bool {
 
 // IsUnversioned returns true if t is in given group, and not in versioned path.
 func IsUnversioned(t *types.Type, group string) bool {
-	return IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) && GetGroup(t) == group
+	return IsUnderApisDir(filepath.Dir(t.Name.Package)) && GetGroup(t) == group
 }
 
 // IsVersioned returns true if t is in given group, and in versioned path.
 func IsVersioned(t *types.Type, group string) bool {
-	dir := filepath.Base(filepath.Dir(filepath.Dir(t.Name.Package)))
-	return IsApisDir(dir) && GetGroup(t) == group
+	return IsUnderApisDir(filepath.Dir(t.Name.Package)) && GetGroup(t) == group
 }
 
 // GetVersion returns version of t.
@@ -252,12 +251,24 @@ func GetVersion(t *types.Type, group string) string {
 
 // GetGroup returns group of t.
 func GetGroup(t *types.Type) string {
-	return filepath.Base(GetGroupPackage(t))
+	// try to retrieve group name from the comment annotation
+	groupName := ""
+	for _, cl := range t.CommentLines {
+		if strings.Contains(cl, "+groupName=") {
+			groupName = strings.Replace(cl, "+groupName=", "", 1)
+			groupName = strings.TrimSpace(groupName)
+		}
+	}
+	// fallback: use versioned package parent directory
+	if groupName == "" {
+		return filepath.Base(GetGroupPackage(t))
+	}
+	return groupName
 }
 
 // GetGroupPackage returns group package of t.
 func GetGroupPackage(t *types.Type) string {
-	if IsApisDir(filepath.Base(filepath.Dir(t.Name.Package))) {
+	if IsUnderApisDir(filepath.Base(filepath.Dir(t.Name.Package))) {
 		return t.Name.Package
 	}
 	return filepath.Dir(t.Name.Package)
@@ -269,6 +280,18 @@ func GetKind(t *types.Type, group string) string {
 		panic(errors.Errorf("Cannot get kind for type not in group %v", t.Name))
 	}
 	return t.Name.Name
+}
+
+// IsUnderApisDir returns true id a directory path is or under the a Kubernetes api directory
+// Example:
+// - pkg/apis/foo/bar	- true
+// - pkg/api/foo	- true
+// - pkg/foo/bar	- false
+func IsUnderApisDir(dir string) bool {
+	if dir == "." {
+		return false
+	}
+	return IsApisDir(filepath.Base(dir)) || IsUnderApisDir(filepath.Dir(dir))
 }
 
 // IsApisDir returns true if a directory path is a Kubernetes api directory


### PR DESCRIPTION
Add support for project with nested groups:
```
pkg/apis
├── addtoscheme_foo_v1alpha1.go
├── apis.go
└── foo
    ├── buz
    │   ├── group.go
    │   └── v1alpha1
    │       ├── bar_types.go
    │       ├── bar_types_test.go
    │       ├── doc.go
    │       ├── register.go
    │       ├── v1alpha1_suite_test.go
    │       └── zz_generated.deepcopy.go
    └── group.go
```

Tracking: #81